### PR TITLE
Resume retrieving tweets from the preivous stopping point

### DIFF
--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -61,10 +61,10 @@ def main():
     elif '.csv' in args.inputfile:
         inputfile_data = pd.read_csv(args.inputfile)
 
-	if not isinstance(idcolumn, NoneType):
-    	inputfile_data = inputfile_data.set_index(args.idcolumn)
-	else:
-    	inputfile_data = inputfile_data.set_index('tweet_id')
+    if not isinstance(idcolumn, NoneType):
+        inputfile_data = inputfile_data.set_index(args.idcolumn)
+    else:
+        inputfile_data = inputfile_data.set_index('tweet_id')
     ids = list(inputfile_data.index)
 
     print('total ids: {}'.format(len(ids)))
@@ -77,6 +77,7 @@ def main():
     last_tweet = None
     if osp.isfile(args.outputfile):
         with open(output_file, 'rb') as f:
+            #may be a large file, seeking without iterating
             f.seek(-2, os.SEEK_END)
             while f.read(1) != b'\n':
                 f.seek(-2, os.SEEK_CUR)
@@ -88,20 +89,20 @@ def main():
 
     print('metadata collection complete')
     print('creating master json file')
-	try:
-		with open(output_file, 'w') as outfile:
-			for go in range(i):
-				print('currently getting {} - {}'.format(start, end))
-				sleep(6)  # needed to prevent hitting API rate limit
-				id_batch = ids[start:end]
-				start += 100
-				end += 100
-				tweets = api.statuses_lookup(id_batch)
-				for tweet in tweets:
-					json.dump(tweet._json, outfile)
-					outfile.write('\n')
-	except:
-		print('exception: continuing to zip the file')
+    try:
+        with open(output_file, 'w') as outfile:
+            for go in range(i):
+                print('currently getting {} - {}'.format(start, end))
+                sleep(6)  # needed to prevent hitting API rate limit
+                id_batch = ids[start:end]
+                start += 100
+                end += 100
+                tweets = api.statuses_lookup(id_batch)
+                for tweet in tweets:
+                    json.dump(tweet._json, outfile)
+                    outfile.write('\n')
+    except:
+        print('exception: continuing to zip the file')
 
     print('creating ziped master json file')
     zf = zipfile.ZipFile('{}.zip'.format(output_file_noformat), mode='w')

--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -85,19 +85,20 @@ def main():
 
     print('metadata collection complete')
     print('creating master json file')
-    with open(output_file, 'w') as outfile:
-        for go in range(i):
-            print('currently getting {} - {}'.format(start, end))
-            sleep(6)  # needed to prevent hitting API rate limit
-            id_batch = ids[start:end]
-            start += 100
-            end += 100
-            tweets = api.statuses_lookup(id_batch)
-            for tweet in tweets:
-                json.dump(tweet._json, outfile)
-                outfile.write('\n')
-        
-    outfile.close()
+	try:
+		with open(output_file, 'w') as outfile:
+			for go in range(i):
+				print('currently getting {} - {}'.format(start, end))
+				sleep(6)  # needed to prevent hitting API rate limit
+				id_batch = ids[start:end]
+				start += 100
+				end += 100
+				tweets = api.statuses_lookup(id_batch)
+				for tweet in tweets:
+					json.dump(tweet._json, outfile)
+					outfile.write('\n')
+	except:
+		print('exception: continuing to zip the file')
 
     print('creating ziped master json file')
     zf = zipfile.ZipFile('{}.zip'.format(output_file_noformat), mode='w')

--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -61,7 +61,7 @@ def main():
     elif '.csv' in args.inputfile:
         inputfile_data = pd.read_csv(args.inputfile)
 
-    if not isinstance(idcolumn, NoneType):
+    if not isinstance(args.idcolumn, type(None)):
         inputfile_data = inputfile_data.set_index(args.idcolumn)
     else:
         inputfile_data = inputfile_data.set_index('tweet_id')

--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -34,7 +34,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-o", "--outputfile", help="Output file name with extension")
     parser.add_argument("-i", "--inputfile", help="Input file name with extension")
-    parser.add_argument("-c", "--id-column", help="tweet id column in the input file, string name")
+    parser.add_argument("-c", "--idcolumn", help="tweet id column in the input file, string name")
 
     args = parser.parse_args()
     if args.inputfile is None or args.outputfile is None:
@@ -61,7 +61,10 @@ def main():
     elif '.csv' in args.inputfile:
         inputfile_data = pd.read_csv(args.inputfile)
 
-    inputfile_data = inputfile_data.set_index('tweet_id')
+	if not isinstance(idcolumn, NoneType):
+    	inputfile_data = inputfile_data.set_index(args.idcolumn)
+	else:
+    	inputfile_data = inputfile_data.set_index('tweet_id')
     ids = list(inputfile_data.index)
 
     print('total ids: {}'.format(len(ids)))


### PR DESCRIPTION
Exceptions in get_metadata.py will stop the script from retrieving data and if we need to restart it will have to go through all the tweets from the beginning again. Instead now, we can resume retrieving tweets. 

I have also added `pandas.Dataframe` to read and manage the file. Again an `try, except` block was added to help the script to move on and zip the file even though it stopped halfway through.

