### PR TITLE
Check for valid API tokens in get_metadata.py

### DIFF
--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -47,6 +47,13 @@ def main():
     auth.set_access_token(keys['access_token'], keys['access_token_secret'])
     api = tweepy.API(auth)
     
+    if api.verify_credentials() == False: 
+        print("Your twitter api credentials are invalid") 
+        sys.exit()
+    else: 
+        print("Your twitter api credentials are valid.") 
+    
+    
     output_file = args.outputfile
     output_file_noformat = output_file.split(".",maxsplit=1)[0]
     print(output_file)


### PR DESCRIPTION
Add a simple check for api tokens

Current Error Messages are not informative and don't allow the user to reduce the problem back to invalid api tokens.
Having no check also results in the script partially running, leading to other issues like #14 later on.