### PR TITLE
get_metadata.py only pulls truncated tweet text

### DIFF
--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -124,10 +124,15 @@ def main():
     with open(output_file_short, 'w') as outfile:
         with open(output_file) as json_data:
             for tweet in json_data:
-                data = json.loads(tweet)            
+                data = json.loads(tweet)  
+                try:  
+                    text = data["full_text"]
+                except KeyError:
+                    text = data["text"]
+                except:          
                 t = {
                     "created_at": data["created_at"],
-                    "full_text": data["full_text"],
+                    "text": text,
                     "in_reply_to_screen_name": data["in_reply_to_screen_name"],
                     "retweet_count": data["retweet_count"],
                     "favorite_count": data["favorite_count"],
@@ -145,7 +150,7 @@ def main():
     with open(output_file_short) as master_file:
         for tweet in master_file:
             data = json.loads(tweet)            
-            f.writerow([data["favorite_count"], data["source"], data["full_text"].encode('utf-8'), data["in_reply_to_screen_name"], data["is_retweet"], data["created_at"], data["retweet_count"], data["id_str"].encode('utf-8')])
+            f.writerow([data["favorite_count"], data["source"], data["text"].encode('utf-8'), data["in_reply_to_screen_name"], data["is_retweet"], data["created_at"], data["retweet_count"], data["id_str"].encode('utf-8')])
     
 
 # main invoked here    

--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -128,8 +128,7 @@ def main():
                 try:  
                     text = data["full_text"]
                 except KeyError:
-                    text = data["text"]
-                except:          
+                    text = data["text"]         
                 t = {
                     "created_at": data["created_at"],
                     "text": text,

--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -97,7 +97,7 @@ def main():
                 id_batch = ids[start:end]
                 start += 100
                 end += 100
-                tweets = api.statuses_lookup(id_batch)
+                tweets = api.statuses_lookup(id_batch, tweet_mode='extended')
                 for tweet in tweets:
                     json.dump(tweet._json, outfile)
                     outfile.write('\n')
@@ -127,7 +127,7 @@ def main():
                 data = json.loads(tweet)            
                 t = {
                     "created_at": data["created_at"],
-                    "text": data["text"],
+                    "full_text": data["full_text"],
                     "in_reply_to_screen_name": data["in_reply_to_screen_name"],
                     "retweet_count": data["retweet_count"],
                     "favorite_count": data["favorite_count"],
@@ -140,12 +140,12 @@ def main():
         
     f = csv.writer(open('{}.csv'.format(output_file_noformat), 'w'))
     print('creating CSV version of minimized json master file') 
-    fields = ["favorite_count", "source", "text", "in_reply_to_screen_name", "is_retweet", "created_at", "retweet_count", "id_str"]                
+    fields = ["favorite_count", "source", "full_text", "in_reply_to_screen_name", "is_retweet", "created_at", "retweet_count", "id_str"]                
     f.writerow(fields)       
     with open(output_file_short) as master_file:
         for tweet in master_file:
             data = json.loads(tweet)            
-            f.writerow([data["favorite_count"], data["source"], data["text"].encode('utf-8'), data["in_reply_to_screen_name"], data["is_retweet"], data["created_at"], data["retweet_count"], data["id_str"].encode('utf-8')])
+            f.writerow([data["favorite_count"], data["source"], data["full_text"].encode('utf-8'), data["in_reply_to_screen_name"], data["is_retweet"], data["created_at"], data["retweet_count"], data["id_str"].encode('utf-8')])
     
 
 # main invoked here    


### PR DESCRIPTION
After twitter updated to 280 Characters, default status requests only return 140 Characters, a parameter had to be added for tweepy to return all 280 Characters of a tweet.