### PR TITLE
Feature: More agressive Api requests and catch Tweepy Exceptions

### DIFF
--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -110,7 +110,7 @@ def main():
                         tweets = api.statuses_lookup(id_batch, tweet_mode='extended')
                         break
                     except tweepy.TweepError as ex:
-                        print('Caught the TweepError exception:\n %s' % e)
+                        print('Caught the TweepError exception:\n %s' % ex)
                         sleep(30*backOffCounter)  # sleep a bit to see if connection Error is resolved before retrying
                         backOffCounter += 1  # increase backoff
                         continue

--- a/data_acquisition/get_metadata.py
+++ b/data_acquisition/get_metadata.py
@@ -104,17 +104,15 @@ def main():
                 id_batch = ids[start:end]
                 start += 100
                 end += 100
+                backOffCounter = 1
                 while True:
                     try:
                         tweets = api.statuses_lookup(id_batch, tweet_mode='extended')
                         break
-                    except IOError as e:
-                        # this catches error 104 which occurs when we wait too long for the rate limit to refresh
-                        print('Caught the IOError exception:\n %s' % e)
-                        continue
-                    except ConnectionError as ex:
-                        print('Caught the ConnectionError exception:\n %s' % e)
-                        sleep(30)  # sleep a bit to see if connection Error is resolved before retrying
+                    except tweepy.TweepError as ex:
+                        print('Caught the TweepError exception:\n %s' % e)
+                        sleep(30*backOffCounter)  # sleep a bit to see if connection Error is resolved before retrying
+                        backOffCounter += 1  # increase backoff
                         continue
                 for tweet in tweets:
                     json.dump(tweet._json, outfile)


### PR DESCRIPTION
This is still in testing!
Not sure if error 104 (when Twitter closes the connection while tweepy waits for the rate limit to refresh) is caught correctly.
If you test this, and the exception appears, please post the output in this pull request!


Additions:

tell tweepy to handle the rate limit:
  
-  Using the tweepy rate limit handling pulls Twitter Data more aggressively, making sure max possible amount of tweets are actually pulled.
-     tweepy tells when ratelimit is hit, and how long it waits

retry after certain exceptions

-     tell tweepy to retry certain http codes instead of quitting
-     catch certain network exceptions tweepy doesn't handle and retry them